### PR TITLE
Unescape path params when using raw path routing.

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -180,13 +181,16 @@ func TestRawURL(t *testing.T) {
 
 	w := new(mockResponseWriter)
 
-	urlParamOne := "%2F"
-	urlParamTwo := "%20"
-	rawUrlPath := fmt.Sprintf("/GET/%s/%s", urlParamOne, urlParamTwo)
-	r, _ := http.NewRequest(http.MethodGet, rawUrlPath, nil)
+	rawParamOne := "©my/key😀"
+	rawParamTwo := "﷼my value😎"
+
+	escapedParamOne := url.PathEscape(rawParamOne)
+	escapedParamTwo := url.PathEscape(rawParamTwo)
+	path := fmt.Sprintf("/GET/%s/%s", escapedParamOne, escapedParamTwo)
+	r, _ := http.NewRequest(http.MethodGet, path, nil)
 	router.ServeHTTP(w, r)
 
-	if paramOne != urlParamOne || paramTwo != urlParamTwo {
+	if paramOne != rawParamOne || paramTwo != rawParamTwo {
 		t.Error("raw URL parsing failed")
 	}
 }


### PR DESCRIPTION
When using raw path routing we only want to find the correct handler via the raw path, not pass the raw path params down to the handler.

This will keep the interface for the down stream dependencies the same. This saves the handlers having to unescape the path params.

All tests passing:
<img width="475" alt="image" src="https://github.com/OneSignal/httprouter/assets/47146346/e95cb3a2-0bd2-442b-9de6-eebf449f40a3">
